### PR TITLE
Fix for infinite loop, etc.

### DIFF
--- a/src/formatstr.nim
+++ b/src/formatstr.nim
@@ -61,18 +61,23 @@ proc nextFmt*(s: var FmtHelper): bool =
   while i < s.s.len:
     case s.s[i]
     of '\\':
-      case s.s[i+1]
-      of '{', '}':
-        s.result.add s.s[i+1]
-        i += 2
-      else: discard
+      if i + 1 > s.s.len:
+        s.result.add s.s[i]
+      else:
+        case s.s[i+1]
+        of '{', '}':
+          s.result.add s.s[i+1]
+          i += 2
+        else:
+          s.result.add s.s[i]
+          i += 1
     of '{':
       var pos: int
       let p = parseUntil(s.s, fs, '}', i+1)
       let pt = if s.namedArgs: parseUntil(fs, s.argString, ':', 0) else: parseInt(fs, pos)
       if not s.namedArgs:
         if pt <= 0:
-          if s.notNumber: raise newException(SyntaxError, "Cannot use unumbered format argument after first numbered ones")
+          if s.notNumber: raise newException(SyntaxError, "Cannot use unnumbered format argument after first numbered ones")
           pos = s.i
           inc(s.i)
         else:
@@ -89,6 +94,8 @@ proc nextFmt*(s: var FmtHelper): bool =
       raise newException(SyntaxError, fmt"Incorrect format at char {i} on {s}")
     else:
       let p = parseUntil(s.s, fs, speChars, i)
+      if p == 0:
+        raise newException(ValueError, "Unexpected error in format string.")
       s.result.add fs
       i += p
 

--- a/src/formatstr.nim
+++ b/src/formatstr.nim
@@ -61,7 +61,7 @@ proc nextFmt*(s: var FmtHelper): bool =
   while i < s.s.len:
     case s.s[i]
     of '\\':
-      if i + 1 > s.s.len:
+      if i + 1 >= s.s.len:
         s.result.add s.s[i]
       else:
         case s.s[i+1]

--- a/src/formatstr.nim
+++ b/src/formatstr.nim
@@ -63,6 +63,7 @@ proc nextFmt*(s: var FmtHelper): bool =
     of '\\':
       if i + 1 >= s.s.len:
         s.result.add s.s[i]
+        i += 1
       else:
         case s.s[i+1]
         of '{', '}':


### PR DESCRIPTION
Fixed a couple of small bugs surrounding backslash handling in a format string.  First, if someone wanted a literal backslash in there, with no '{', '}' or '\' after, the algorithm would hang, because the index wasn't advancing when a backslash wasn't followed by one of those things (backslash forever!).  Second, if that backslash were the last character of the input, then you'd get a nice array index out of bounds error.